### PR TITLE
Add a couple endpoints for v2 in experimental

### DIFF
--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -16,3 +16,5 @@ export * from './runs';
 export * from './series';
 export * from './users';
 export * from './variables';
+
+export * from './v2';

--- a/src/endpoints/v2/Run.ts
+++ b/src/endpoints/v2/Run.ts
@@ -1,0 +1,33 @@
+import { HTTPOptions, httpV2 } from "../../http";
+
+// all temporary until v2 officially releases
+
+export type OK = { ok: boolean; };
+export type V2Error = { error: string; };
+
+export enum RunVerificationStatus {
+    Pending = 0,
+    Verified = 1,
+    Rejected = 2,
+};
+
+export type PutRunVerificationRequest = {
+    runId: string;
+    verified: RunVerificationStatus;
+    reason?: string;
+}
+
+/** Sets the status of a run. */
+export function PutRunVerification(params: PutRunVerificationRequest, PHPSESSID: string, options?: HTTPOptions) {
+    return httpV2('/PutRunVerification', 'post', PHPSESSID, { body: params, ...options }) as Promise<OK | V2Error>;
+}
+
+export type PutRunAssigneeRequest = {
+    assigneeId: string;
+    runId: string;
+}
+
+/** Assigns a run to a verifier. */
+export function PutRunAssignee(params: PutRunAssigneeRequest, PHPSESSID: string, options?: HTTPOptions) {
+    return httpV2('/PutRunAssignee', 'post', PHPSESSID, { body: params, ...options }) as Promise<Record<string, never> | V2Error>;
+}

--- a/src/endpoints/v2/index.ts
+++ b/src/endpoints/v2/index.ts
@@ -1,0 +1,1 @@
+export * from './Run';

--- a/src/http.ts
+++ b/src/http.ts
@@ -4,7 +4,7 @@ import { Data, Paginated, PaginatedData, PaginatedParams, ResponseError } from '
 import SRCError from './SRCError';
 export const VERSION = "2.8.0";
 
-const BASE_URL = "https://www.speedrun.com/api/v1";
+const BASE_URL = "https://www.speedrun.com/api";
 
 const bn = new Bottleneck({
 	reservoir: 100,
@@ -86,11 +86,24 @@ export async function get<Response, Err extends ResponseError = ResponseError>(u
 		url += `?${Object.entries(queryParams).map(([k, v]) => `${k}=${v}`).join('&')}`;
 	}
 
-	return rawHTTP<Response, Err>(`${BASE_URL}${url}`, 'get', { ...opts, headers: { ...(key ? { 'X-API-Key': key } : {}), ...opts.headers}});
+	return rawHTTP<Response, Err>(`${BASE_URL}/v1${url}`, 'get', { ...opts, headers: { ...(key ? { 'X-API-Key': key } : {}), ...opts.headers}});
 }
 
 export async function http<Response, Err extends ResponseError = ResponseError>(url: string, method: Exclude<HTTPType, 'get'>, key: string, options: RawHTTPOptions = {}) {
-	return rawHTTP<Response, Err>(`${BASE_URL}${url}`, method, { ...options, headers: { 'X-API-Key': key, ...options.headers } })
+	return rawHTTP<Response, Err>(`${BASE_URL}/v1${url}`, method, { ...options, headers: { 'X-API-Key': key, ...options.headers } })
+}
+
+// entirely temporary, not good, very bad
+export async function httpV2(url: string, method: HTTPType = 'get', PHPSESSID?: string, options: RawHTTPOptions = {}) {
+    const headers = {
+        'Cookie': `PHPSESSID=${PHPSESSID}`,
+        ...options.headers,
+    };
+
+    return rawHTTP<unknown, any>(`${BASE_URL}/v2${url}`, method, {
+        ...options,
+        headers,
+    })
 }
 
 export async function rawHTTP<Response, Err extends ResponseError = ResponseError>(url: string, method: HTTPType, options: RawHTTPOptions = {}) {


### PR DESCRIPTION
Adds `PutRunVerification` and `PutRunAssignee`

This implementation is least effort, since whenever v2 fully releases this'll get a huge rewrite and proper support. But it's super lazy atm